### PR TITLE
Update class-avia-gutenberg.php

### DIFF
--- a/temp_fixes/Enfold_4_5_3/config-gutenberg/class-avia-gutenberg.php
+++ b/temp_fixes/Enfold_4_5_3/config-gutenberg/class-avia-gutenberg.php
@@ -920,7 +920,7 @@ if( ! class_exists( 'Avia_Gutenberg' ) )
 									'id'	=> 'edit',
 									'title'	=> $title,
 									'href'	=> $edit_url,
-									'meta'	=> array( 'target' => 'blank' )
+									'meta'	=> array( )
 								);
 
 					$wp_admin_bar->add_menu( $menu );


### PR DESCRIPTION
Prevents the admin bar "Edit" link from opening in a new tab/page. This is confusing as other themes do not alter the target of the admin bar edit link. You can always control+click to open in a new tab/page but you cannot if the target is set to "_blank". Plus it isn't ADA compliant with regards to accessible web design. Hope my 'alteration' fixes the issue. I simply commented the line out on my site and worked great. Thank you!