### PR TITLE
Allow steps on wc quantity change

### DIFF
--- a/temp_fixes/Enfold_5_2_1/config-woocommerce/woocommerce-mod.js
+++ b/temp_fixes/Enfold_5_2_1/config-woocommerce/woocommerce-mod.js
@@ -49,7 +49,6 @@ jQuery( function($)
 
 			var	max = parseFloat( number.attr( 'max' ) ),
 				min = parseFloat( number.attr( 'min' ) ),
-				step = parseInt( number.attr( 'step' ), 10 ),
 				newNum = cloned.insertAfter( number );
 				newNum.addClass('no-spin-num');
 				number.remove();
@@ -72,6 +71,7 @@ jQuery( function($)
 
 				minus.on( 'click', function()
 				{
+					var step = parseInt( newNum.attr( 'step' ), 10 );
 					var the_val = parseInt( newNum.val(), 10 );
 					if( isNaN( the_val ) )
 					{
@@ -86,6 +86,7 @@ jQuery( function($)
 
 				plus.on( 'click', function()
 				{
+					var step = parseInt( newNum.attr( 'step' ), 10 );
 					var the_val = parseInt( newNum.val(), 10 );
 					if( isNaN( the_val ) )
 					{


### PR DESCRIPTION
Hi there,

We developed a plugin that changes the step of the quantity input by user choice.
https://barn2.com/wordpress-plugins/woocommerce-quantity-manager/

Our customers are complaining that the step feature isn't working on your theme specifically.

The issue is that, if you have a variable product, and one of the variations has a step different than other variations, your theme doesn't have that in consideration.

You can see an example here:
https://quantitymanager.barn2.com/product/hoodie/

If you choose the red option, the step is 2.
If you choose all other options the step is 1.
Try to increment or decrement the quantity amount, and verify that when you choose the red option and increase the amount, the increments will be by 2, and 1 for all other options.

On your theme you add new plus and minus buttons, which don't have in consideration if the step changes.

We fully support your theme in all our plugins, so we try to integrate all the necessary features in them, so that our customers can have a seamless experience when working with our plugins and the Enfold theme.

So I've created this PR, only for reference, so that you can easily see the minor changes that you could add on your side, to make it more robust and more flexible.

Could you guys please add this change on the next version of your theme?

Thank you.

Cheers